### PR TITLE
Correct project URLs in Python distributions (setup.py)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ install_requires = [
 ]
 
 name = "fs_server"
-gh_repo = "https://github.com/weaming/{}".format(name)
+gh_repo = "https://github.com/weaming/fs-server"
 
 setup(
     name=name,  # Required


### PR DESCRIPTION
PyPI project page https://pypi.org/project/fs-server/ (with a dash) is currently linking to https://github.com/weaming/fs_server (with an underscore), which is a 404.

There could be a case for renaming this project to "fs-server". `pip` et al generally prefer dashes for distribution names, and transform foo_bar to foo-bar. I haven't done so, in order to keep this change minimal.